### PR TITLE
add a duration flag for non-infinite runtime

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,6 @@ jobs:
         run: nix develop -c cargo build -p linux-apex-hypervisor --release
       - name: Run example
         run: |
-          nix develop -c \
-            systemd-run --user --scope \
-              timeout -s SIGINT --preserve-status --verbose --foreground --kill-after=10s $DURATION \
-                target/release/linux-apex-hypervisor examples/hello_part/hypervisor_config.yaml
+          nix develop -c systemd-run --user --scope -- \
+            target/release/linux-apex-hypervisor --duration $DURATION \
+            examples/hello_part/hypervisor_config.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,6 +536,7 @@ dependencies = [
  "apex-rs",
  "clap",
  "clone3",
+ "humantime 1.3.0",
  "humantime-serde",
  "itertools",
  "libc",

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -23,6 +23,7 @@ procfs = "0.14"
 itertools = "0.10"
 clap = { version = "3", features = [ "derive" ] }
 serde_yaml = "0"
+humantime = "1"
 humantime-serde = "1"
 memmap2 = "0.5.5"
 log = "0"


### PR DESCRIPTION
this allows to run the hypervisor for a specified timer, after which it will gracefully terminate itself. This is particular useful for CI setups, as it allows for test cases that only require a known number of major frames.

Further on this fixes #4, a bug which we discovered in the meantime. The bug causes the shutdown of the hypervisor to fail _sometimes_, as faulty method for finding the origin cgroup was used (while we already had a correct one executed earlier on...). Therefore fd97feb49ef75415873cc0d70739609e00336509 reverts to just using the already known original cgroup that the hypervisor was spawned in.