### PR TITLE
hypervisor: rename unwind() to sighdlr()

### DIFF
--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -50,7 +50,7 @@ fn main() -> LeveledResult<()> {
     // Register Handler for SIGINT
     // Maybe use https://crates.io/crates/signal-hook instead
     let sig_action = SigAction::new(
-        SigHandler::Handler(unwind),
+        SigHandler::Handler(sighdlr),
         SaFlags::empty(),
         SigSet::empty(),
     );
@@ -124,7 +124,7 @@ fn main() -> LeveledResult<()> {
     }
 }
 
-pub extern "C" fn unwind(_: i32) {
+pub extern "C" fn sighdlr(_: i32) {
     print!("\r");
     std::io::stdout().flush().unwrap();
     info!("Exiting");


### PR DESCRIPTION
This commit renames the unwind() function to sighdlr(), in order to indicate the one and only purpose of this function: to perform a certain action (clean-up) in case that a signal gets caught.