### PR TITLE
fix panic on empty read from file

### DIFF
--- a/partition/src/apex.rs
+++ b/partition/src/apex.rs
@@ -152,11 +152,12 @@ impl ApexSamplingPortP4 for ApexLinuxPartition {
         sampling_port_id: SamplingPortId,
         message: &mut [ApexByte],
     ) -> Result<(Validity, MessageSize), ErrorReturnCode> {
-        if let Some((port, val)) = SAMPLING_PORTS
-            .read()
-            .unwrap()
-            .get(sampling_port_id as usize - 1)
-        {
+        let read = if let Ok(read) = SAMPLING_PORTS.read() {
+            read
+        } else {
+            return Err(ErrorReturnCode::NotAvailable);
+        };
+        if let Some((port, val)) = read.get(sampling_port_id as usize - 1) {
             if let Some(port) = CONSTANTS.sampling.get(*port) {
                 if message.is_empty() {
                     return Err(ErrorReturnCode::InvalidParam);


### PR DESCRIPTION
This fixes #16 a read from an empty file or from the end of a file. I'm not entirely sure under which conditions the file can be empty, but the cursor might be moved between seeking it to the beginnging of the file and reading from it. I encountered the problem only occasionally when running the hypervisor with two partitions for a while.
