### PR TITLE
core: remove CGroups by depth

### DIFF
--- a/core/src/cgroup.rs
+++ b/core/src/cgroup.rs
@@ -101,7 +101,7 @@ impl CGroup {
             bail!("{} is not a valid cgroup", self.path.display());
         }
 
-        Ok(!fs::read(self.path.join("cgroup.procs"))?.is_empty())
+        Ok(fs::read_to_string(self.get_events_path())?.contains("populated 1\n"))
     }
 
     /// Checks whether this cgroup is frozen


### PR DESCRIPTION
This commit provides a partial fix for #17, by fixing the errors that happened during the removal of a CGroup.

The fix works by obtaining the sub-directories of a CGroup in a sorted manner, meaning that the outer-most directories are being removed before the lower ones are. This step is necessary, because removing non-empty directories is prohibited.

Beside this, it also adds a recovery for `EBUSY` errors, as they are not critical and simply indicate that a retry could be successful.