### PR TITLE
Avoid collisions in cgroup names when running multiple instances

### DIFF
--- a/hypervisor/src/hypervisor/linux.rs
+++ b/hypervisor/src/hypervisor/linux.rs
@@ -38,12 +38,12 @@ impl Hypervisor {
         let prev_cg = PathBuf::from(config.cgroup.parent().unwrap());
 
         let schedule = config.generate_schedule().lev(ErrorLevel::ModuleInit)?;
-        let cg = CGroup::new_root(
-            &prev_cg,
-            config.cgroup.file_name().unwrap().to_str().unwrap(),
-        )
-        .typ(SystemError::CGroup)
-        .lev(ErrorLevel::ModuleInit)?;
+        let pid = std::process::id();
+        let file_name = config.cgroup.file_name().unwrap().to_str().unwrap();
+        let cg_name = format!("{file_name}-{pid}");
+        let cg = CGroup::new_root(&prev_cg, cg_name.as_str())
+            .typ(SystemError::CGroup)
+            .lev(ErrorLevel::ModuleInit)?;
 
         let mut hv = Self {
             cg,


### PR DESCRIPTION
This joins the hypervisor's process id to the name of the directory that is created at the root of the CGroup hirarchy. This avoids file-name collisions when multiple hypervisors are run at the same time from within the same user-slice.
