### PR TITLE
core: revert the cgroup rewrite

### DIFF
--- a/core/src/cgroup.rs
+++ b/core/src/cgroup.rs
@@ -1,434 +1,238 @@
-//! Implementation of the Linux *cgroup* facility
+//! Implementation of the Linux *cgroup* feature
 //!
-//! This module provides an interface for the Linux cgroup facility.
-//! Interfacing applications either create or import a cgroup, which
-//! will then be used to build a tree to keep track of all following
-//! sub-cgroups.
-//!
-//! This approach makes it possible to only manage a certain sub-tree
-//! of cgroups, thereby saving resources. Alternatively, the root cgroup
-//! may be imported, keeping track of all cgroups existing on the host system.
-use std::fs::{self};
-use std::io::BufRead;
+//! This mdoule itself assumes a good understanding of the relevant technology,
+//! meaning that certain concepts won't be explained here.
+//! For more information regarding cgroup, have a look at the accompanying
+//! man-page and [this](https://docs.kernel.org/admin-guide/cgroup-v2.html) resource.
+use std::collections::HashMap;
+use std::fs::{read_to_string, File};
+use std::os::unix::prelude::{AsRawFd, OwnedFd};
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, bail, Ok};
+use anyhow::anyhow;
 use itertools::Itertools;
-use nix::sys::statfs;
 use nix::unistd::Pid;
+use polling::{Event, Poller};
 use walkdir::WalkDir;
 
-/// A single cgroup inside our tree of managed cgroups
-///
-/// The tree is not represented by a traditional tree data structure,
-/// as this is very complicated in Rust. Instead, the tree is "calculated"
-/// by the path alone.
-#[derive(Debug)]
+use crate::error::{ResultExt, SystemError, TypedResult};
+
+/// An internal reference to a certain cgroup
+// TODO think about completely changing this.
+// Because CGroups are a hierarchy and Parents need to consider their children,
+// A different representation may be necessary, probably a tree with n children.
+// Also maybe we dont even need to delete the cgroups after we are done
+// We may need to verify "Domain" "Domain Threaded" and "Thread" state of CGroups
+// TODO it should be possible to use an already created cgroup incase the user provides us a group with cpuset-enabled
+#[derive(Debug, Clone)]
 pub struct CGroup {
     path: PathBuf,
 }
 
 impl CGroup {
-    /// Creates a new cgroup as the root of a sub-tree
-    ///
-    /// path must be the path of an already existing cgroup
-    pub fn new_root<P: AsRef<Path>>(path: P, name: &str) -> anyhow::Result<Self> {
-        // Double-checking if path is cgroup does not hurt, as it is
-        // better to not potentially create a directory at a random location.
-        if !is_cgroup(path.as_ref())? {
-            bail!("{} is not a valid cgroup", path.as_ref().display());
-        }
+    const MEMBER_FILE: &'static str = "cgroup.procs";
+    const FREEZE_FILE: &'static str = "cgroup.freeze";
+    const EVENTS_FILE: &'static str = "cgroup.events";
 
-        let path = PathBuf::from(path.as_ref()).join(name);
-
-        // TODO this is a hotfix for #17. We should revisit this issue, trying to find
-        // our why the same CGroup is created multiple times.
-        if path.exists() {
-            warn!("CGroup {path:?} already exists");
-        } else {
-            // will fail if the path already exists
-            fs::create_dir(&path)?;
-        }
-
-        Self::import_root(&path)
+    /// Returns the first mount point on the host filesystem of the cgroup that this process belongs to
+    pub fn mount_point() -> TypedResult<PathBuf> {
+        procfs::process::Process::myself()
+            .typ(SystemError::Panic)?
+            .mountinfo()
+            .typ(SystemError::Panic)?
+            .iter()
+            .find(|m| m.fs_type.eq("cgroup2")) // TODO A process can have several cgroup mounts
+            .ok_or_else(|| anyhow!("no cgroup2 mount found"))
+            .typ(SystemError::Panic)
+            .map(|m| m.mount_point.clone())
     }
 
-    /// Imports an already existing cgroup as the root of a sub-tree
-    pub fn import_root<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
-        let path = PathBuf::from(path.as_ref());
+    /// Create a cgroup inside another one
+    // TODO: Switch to a tree data structure for cgroups.
+    pub fn new<P: AsRef<Path>>(parent: P, child_name: &str) -> TypedResult<Self> {
+        let path = PathBuf::from(parent.as_ref()).join(child_name);
+        //trace!("New CGroup: {path:?}");
 
-        if !is_cgroup(&path)? {
-            bail!("{} is not a valid cgroup", path.display());
+        if !path.exists() {
+            trace!("Creating Cgroup, {path:?}");
+            std::fs::create_dir(&path).typ(SystemError::CGroup)?;
         }
 
-        Ok(CGroup {
-            path: path.to_path_buf(),
-        })
+        // TODO use cpuset with feature opt in
+        //let cont = path.join("cgroup.subtree_control");
+        //println!("{cont:?}");
+        //unsafe {exit(1)};
+        //std::fs::write(path.join("cgroup.subtree_control"), b"+pids")?;
+        //sleep(Duration::from_secs(1));
+        //sleep(Duration::from_secs(1));
+
+        Ok(CGroup { path })
     }
 
-    /// Creates a sub-cgroup inside this one
-    pub fn new(&self, name: &str) -> anyhow::Result<Self> {
-        Self::new_root(&self.path, name)
+    /// Returns a file descriptor to the list of the processes that belong to this cgroup
+    /// TODO: Does this need to be public?
+    pub fn get_procs_fd(&self) -> TypedResult<OwnedFd> {
+        File::open(self.path.join(Self::MEMBER_FILE))
+            .typ(SystemError::CGroup)
+            .map(OwnedFd::from)
     }
 
     /// Moves a process to this cgroup
-    pub fn mv(&self, pid: Pid) -> anyhow::Result<()> {
-        if !is_cgroup(&self.path)? {
-            bail!("{} is not a valid cgroup", self.path.display());
-        }
-
-        fs::write(self.path.join("cgroup.procs"), pid.to_string())?;
-        Ok(())
+    pub fn add_process(&self, pid: Pid) -> TypedResult<()> {
+        Self::add_process_to(&self.path, pid)
     }
 
-    /// Returns all PIDs associated with this cgroup
-    pub fn get_pids(&self) -> anyhow::Result<Vec<Pid>> {
-        if !is_cgroup(&self.path)? {
-            bail!("{} is not a valid cgroup", self.path.display());
-        }
+    /// Returns a Vec containing the PIDs of all processes beloning to this cgroup
+    pub fn member(&self) -> TypedResult<Vec<Pid>> {
+        read_to_string(self.path().join(Self::MEMBER_FILE))
+            .map(|s| {
+                s.lines()
+                    .flat_map(|l| l.parse())
+                    .map(Pid::from_raw)
+                    .collect()
+            })
+            .typ(SystemError::CGroup)
+    }
 
-        let pids: Vec<Pid> = fs::read(self.path.join("cgroup.procs"))?
+    /// Moves a process to any cgroup
+    pub fn add_process_to<P: AsRef<Path>>(path: P, pid: Pid) -> TypedResult<()> {
+        std::fs::write(path.as_ref().join(Self::MEMBER_FILE), pid.to_string())
+            .typ(SystemError::CGroup)
+    }
+
+    /// Returns a file descriptor to the events file of this cgroup
+    // TODO: Does this need to be public?
+    pub fn events_file(&self) -> TypedResult<OwnedFd> {
+        File::open(self.path().join(Self::EVENTS_FILE))
+            .typ(SystemError::CGroup)
+            .map(OwnedFd::from)
+    }
+
+    /// Returns a Vec containing the events of this cgroup
+    // TODO: It's weird that member() and this function do a similar thing but have so different names.
+    pub fn read_event_file(&self) -> TypedResult<HashMap<String, bool>> {
+        let ctn = read_to_string(self.path().join(Self::EVENTS_FILE)).typ(SystemError::CGroup)?;
+        Ok(ctn
             .lines()
-            .map(|line| Pid::from_raw(line.unwrap().parse().unwrap()))
-            .collect();
-
-        Ok(pids)
+            .filter(|l| !l.is_empty())
+            .filter_map(|l| l.split_once(' '))
+            .map(|(k, b)| (k.to_string(), b.eq("1")))
+            .collect())
     }
 
-    /// Checks whether this cgroup is populated
-    pub fn populated(&self) -> anyhow::Result<bool> {
-        if !is_cgroup(&self.path)? {
-            bail!("{} is not a valid cgroup", self.path.display());
-        }
-
-        Ok(fs::read_to_string(self.get_events_path())?.contains("populated 1\n"))
+    /// Checks if this cgroup is frozen
+    pub fn is_frozen(&self) -> TypedResult<bool> {
+        let event = self.read_event_file()?;
+        event
+            .get("frozen")
+            .ok_or_else(|| anyhow!("No \"frozen\" in event file"))
+            .typ(SystemError::CGroup)
+            .map(|b| *b)
     }
 
-    /// Checks whether this cgroup is frozen
-    pub fn frozen(&self) -> anyhow::Result<bool> {
-        if !is_cgroup(&self.path)? {
-            bail!("{} is not a valid cgroup", self.path.display());
-        }
-
-        // We need to check for the existance of cgroup.freeze, because
-        // this file does not exist on the root cgroup.
-        let path = self.path.join("cgroup.freeze");
-        if !path.exists() {
-            return Ok(false);
-        }
-
-        Ok(fs::read(&path)? == b"1\n")
+    /// Checks if this cgroup contains any active processes
+    pub fn is_populated(&self) -> TypedResult<bool> {
+        let event = self.read_event_file()?;
+        event
+            .get("populated")
+            .ok_or_else(|| anyhow!("No \"populated\" in event file"))
+            .typ(SystemError::CGroup)
+            .map(|b| *b)
     }
 
-    /// Freezes this cgroup (does nothing if already frozen)
-    pub fn freeze(&self) -> anyhow::Result<()> {
-        if !is_cgroup(&self.path)? {
-            bail!("{} is not a valid cgroup", self.path.display());
-        }
+    /// Kills all processes in this cgroup with a given timeout
+    ///
+    /// Returns
+    /// Ok(true) in case of success
+    /// Ok(false) in case of a timeout
+    /// Err(_) in case an error
+    pub fn kill_all_timeout(&self, timeout: Duration) -> TypedResult<bool> {
+        let start = Instant::now();
 
-        // We need to check for the existance of cgroup.freeze, because
-        // this file does not exist on the root cgroup.
-        let path = self.path.join("cgroup.freeze");
-        if !path.exists() {
-            bail!("cannot freeze the root cgroup");
-        }
+        std::fs::write(self.path.join("cgroup.kill"), "1").typ(SystemError::CGroup)?;
 
-        Ok(fs::write(path, "1")?)
-    }
+        let event_file = self.events_file()?;
+        let poller = Poller::new()
+            .map_err(anyhow::Error::from)
+            .typ(SystemError::Panic)?;
+        poller
+            .add(event_file.as_raw_fd(), Event::readable(42))
+            .map_err(anyhow::Error::from)
+            .typ(SystemError::Panic)?;
 
-    /// Unfreezes this cgroup (does nothing if not frozen)
-    pub fn unfreeze(&self) -> anyhow::Result<()> {
-        if !is_cgroup(&self.path)? {
-            bail!("{} is not a valid cgroup", self.path.display());
-        }
+        // We cannot use timeout directly and pass it to poller, as it may report a change of the
+        // event file that is unrelated to the populated property.
+        let mut leftover_time = timeout.saturating_sub(start.elapsed());
+        loop {
+            // Stop loop if time is exceeded
+            if leftover_time <= Duration::ZERO {
+                return Ok(false);
+            };
 
-        // We need to check for the existance of cgroup.freeze, because
-        // this file does not exist on the root cgroup.
-        let path = self.path.join("cgroup.freeze");
-        if !path.exists() {
-            bail!("cannot unfreeze the root cgroup");
-        }
-
-        Ok(fs::write(path, "0")?)
-    }
-
-    /// Kills all processes in this cgroup and returns once this
-    /// procedure is finished
-    pub fn kill(&self) -> anyhow::Result<()> {
-        if !is_cgroup(&self.path)? {
-            bail!("{} is not a valid cgroup", self.path.display());
-        }
-
-        // We need to check for the existance of cgroup.kill, because
-        // this file does not exist on the root cgroup.
-        let killfile = self.path.join("cgroup.kill");
-        if !killfile.exists() {
-            bail!("cannot kill the root cgroup");
-        }
-
-        // Emit the kill signal to all processes inside the cgroup
-        trace!("writing '1' to {}", killfile.display());
-        fs::write(killfile, "1")?;
-
-        // Check if all processes were terminated successfully
-        let mut i = 1;
-        while i <= 64 {
-            trace!("kill iteration ({i}/64)");
-            if !self.populated()? {
-                return Ok(());
+            // Check if cgroup is populated (check may take time)
+            if !self.is_populated()? {
+                return Ok(true);
             }
-            i += 1;
+
+            // Check again if time is exceeded
+            leftover_time = timeout.saturating_sub(start.elapsed());
+            if leftover_time <= Duration::ZERO {
+                return Ok(false);
+            };
+
+            // Poll wait for event with given leftover time as timeout
+            poller
+                .wait(Vec::new().as_mut(), Some(leftover_time))
+                .typ(SystemError::Panic)?;
+            poller
+                .modify(event_file.as_raw_fd(), Event::readable(42))
+                .map_err(anyhow::Error::from)
+                .typ(SystemError::Panic)?;
+
+            // determine new leftover time
+            leftover_time = timeout.saturating_sub(start.elapsed());
         }
-        bail!("failed to kill the cgroup")
     }
 
-    /// Returns the path of this cgroup
-    pub fn get_path(&self) -> PathBuf {
-        self.path.clone()
-    }
-
-    /// Returns the path of the event file, which may be polled
-    pub fn get_events_path(&self) -> PathBuf {
-        self.path.join("cgroup.events")
-    }
-
-    /// Kills all processes and removes the current cgroup
-    pub fn rm(&self) -> anyhow::Result<()> {
-        if !is_cgroup(&self.path)? {
-            bail!("{} is not a valid cgroup", self.path.display());
-        }
-
-        // Calling kill will also kill all sub cgroup processes
-        self.kill()?;
-
-        // Delete all cgroups from deepest to highest.
-        // It is necessary to delete the outer-most directories first, because
-        // a non-empty directory may not be deleted.
-        trace!("Calling remove on {}", &self.path.display());
+    /// Deletes a cgroup by killing it's processes and removing the directory afterwards
+    pub fn delete(&self, timeout: Duration) -> TypedResult<()> {
+        self.kill_all_timeout(timeout)?;
         for d in WalkDir::new(&self.path)
             .into_iter()
             .flatten()
             .filter(|e| e.file_type().is_dir())
             .sorted_by(|a, b| a.depth().cmp(&b.depth()).reverse())
         {
-            trace!("Removing cgroup {}", &d.path().display());
-            fs::remove_dir(d.path())?;
+            std::fs::remove_dir(&d.path()).typ(SystemError::CGroup)?;
+            trace!("Removed {:?}", d.path().as_os_str())
         }
-
         Ok(())
     }
 
-    // TODO: Implement functions to fetch the parents and children
+    /// Returns the absolute path of this cgroup on the host file system
+    pub fn path(&self) -> PathBuf {
+        self.path.clone()
+    }
+
+    /// Freezes this cgroup
+    pub fn freeze(&self) -> TypedResult<()> {
+        std::fs::write(self.path.join(Self::FREEZE_FILE), "1").typ(SystemError::CGroup)
+    }
+
+    /// Unfreezes this cgroup
+    pub fn unfreeze(&self) -> TypedResult<()> {
+        std::fs::write(self.path.join(Self::FREEZE_FILE), "0").typ(SystemError::CGroup)
+    }
+
+    /// Returns a directory file descriptor to this cgroup
+    pub fn get_fd(&self) -> TypedResult<File> {
+        File::open(&self.path).typ(SystemError::CGroup)
+    }
 }
 
-/// Returns the first cgroup2 mount point found on the host system
-pub fn mount_point() -> anyhow::Result<PathBuf> {
-    // TODO: This is an awful old function, replace it!
-    procfs::process::Process::myself()?
-        .mountinfo()?
-        .iter()
-        .find(|m| m.fs_type.eq("cgroup2")) // TODO A process can have several cgroup mounts
-        .ok_or_else(|| anyhow!("no cgroup2 mount found"))
-        .map(|m| m.mount_point.clone())
-}
-
-/// Returns the path relative to the cgroup mount to
-/// which cgroup this process belongs to
-pub fn current_cgroup() -> anyhow::Result<PathBuf> {
-    let path = procfs::process::Process::myself()?
-        .cgroups()?
-        .first()
-        .ok_or(anyhow!("cannot obtain cgroup"))?
-        .pathname
-        .clone();
-    let path = &path[1..path.len()]; // Remove the leading '/'
-
-    Ok(PathBuf::from(path))
-}
-
-/// Checks if path is a valid cgroup by comparing the device id
-fn is_cgroup(path: &Path) -> anyhow::Result<bool> {
-    let st = statfs::statfs(path)?;
-    Ok(st.filesystem_type() == statfs::CGROUP2_SUPER_MAGIC)
-}
-
-#[cfg(test)]
-mod tests {
-    // The tests must be run as root with --test-threads=1
-
-    use std::{io, process};
-
-    use super::*;
-
-    #[test]
-    fn new_root() {
-        let path = get_path().join("cgroup_test");
-        assert!(!path.exists()); // Ensure, that it does not already exist
-
-        let cg = CGroup::new_root(get_path(), "cgroup_test").unwrap();
-        assert!(path.exists() && path.is_dir());
-
-        cg.rm().unwrap();
-        assert!(!path.exists());
-    }
-
-    #[test]
-    fn import_root() {
-        let path = get_path().join("cgroup_test");
-        assert!(!path.exists()); // Ensure, that it does not already exist
-        fs::create_dir(&path).unwrap();
-
-        let cg = CGroup::import_root(&path).unwrap();
-
-        cg.rm().unwrap();
-        assert!(!path.exists());
-    }
-
-    #[test]
-    fn new() {
-        let path_cg1 = get_path().join("cgroup_test");
-        let path_cg2 = path_cg1.join("cgroup_test2");
-        assert!(!path_cg1.exists()); // Ensure, that it does not already exist
-
-        let cg1 = CGroup::new_root(get_path(), "cgroup_test").unwrap();
-        assert!(path_cg1.exists() && path_cg1.is_dir());
-        assert!(!path_cg2.exists());
-
-        let _cg2 = cg1.new("cgroup_test2").unwrap();
-        assert!(path_cg2.exists() && path_cg2.is_dir());
-
-        cg1.rm().unwrap();
-
-        assert!(!path_cg2.exists());
-        assert!(!path_cg1.exists());
-    }
-
-    #[test]
-    fn mv() {
-        let mut proc = spawn_proc().unwrap();
-        let pid = Pid::from_raw(proc.id() as i32);
-
-        let cg1 = CGroup::new_root(get_path(), "cgroup_test").unwrap();
-        let cg2 = cg1.new("cgroup_test2").unwrap();
-
-        cg1.mv(pid).unwrap();
-        cg2.mv(pid).unwrap();
-        proc.kill().unwrap();
-
-        cg1.rm().unwrap();
-    }
-
-    #[test]
-    fn get_pids() {
-        let mut proc = spawn_proc().unwrap();
-        let pid = Pid::from_raw(proc.id() as i32);
-
-        let cg1 = CGroup::new_root(get_path(), "cgroup_test").unwrap();
-        let cg2 = cg1.new("cgroup_test2").unwrap();
-
-        assert!(cg1.get_pids().unwrap().is_empty());
-        assert!(cg2.get_pids().unwrap().is_empty());
-
-        cg1.mv(pid).unwrap();
-        let pids = cg1.get_pids().unwrap();
-        assert!(!pids.is_empty());
-        assert!(cg2.get_pids().unwrap().is_empty());
-        assert_eq!(pids.len(), 1);
-        assert_eq!(pids[0], pid);
-
-        cg2.mv(pid).unwrap();
-        let pids = cg2.get_pids().unwrap();
-        assert!(!pids.is_empty());
-        assert!(cg1.get_pids().unwrap().is_empty());
-        assert_eq!(pids.len(), 1);
-        assert_eq!(pids[0], pid);
-
-        proc.kill().unwrap();
-
-        cg1.rm().unwrap();
-    }
-
-    #[test]
-    fn populated() {
-        let mut proc = spawn_proc().unwrap();
-        let pid = Pid::from_raw(proc.id() as i32);
-        let cg = CGroup::new_root(get_path(), "cgroup_test").unwrap();
-
-        assert!(!cg.populated().unwrap());
-        assert_eq!(cg.populated().unwrap(), cg.get_pids().unwrap().len() > 0);
-
-        cg.mv(pid).unwrap();
-        assert!(cg.populated().unwrap());
-        assert_eq!(cg.populated().unwrap(), cg.get_pids().unwrap().len() > 0);
-
-        proc.kill().unwrap();
-
-        cg.rm().unwrap();
-    }
-
-    #[test]
-    fn frozen() {
-        let mut proc = spawn_proc().unwrap();
-        let pid = Pid::from_raw(proc.id() as i32);
-        let cg = CGroup::new_root(get_path(), "cgroup_test").unwrap();
-
-        // Freeze an empty cgroup
-        assert!(!cg.frozen().unwrap());
-        cg.freeze().unwrap();
-        assert!(cg.frozen().unwrap());
-
-        // Unfreeze the empty cgroup
-        cg.unfreeze().unwrap();
-        assert!(!cg.frozen().unwrap());
-
-        // Do the same with a non-empty cgroup
-        cg.mv(pid).unwrap();
-        cg.freeze().unwrap();
-        assert!(cg.frozen().unwrap());
-        cg.unfreeze().unwrap();
-        assert!(!cg.frozen().unwrap());
-
-        proc.kill().unwrap();
-
-        cg.rm().unwrap();
-    }
-
-    #[test]
-    fn kill() {
-        let proc = spawn_proc().unwrap();
-        let pid = Pid::from_raw(proc.id() as i32);
-        let cg = CGroup::new_root(get_path(), "cgroup_test").unwrap();
-
-        // Kill an empty cgroup
-        cg.kill().unwrap();
-
-        // Do the same with a non-empty cgroup
-        cg.mv(pid).unwrap();
-        assert!(cg.populated().unwrap());
-        cg.kill().unwrap();
-
-        cg.rm().unwrap();
-
-        // TODO: Check if the previous PID still exists (although unstable because the OS may re-assign)
-    }
-
-    #[test]
-    fn is_cgroup() {
-        assert!(super::is_cgroup(&get_path()).unwrap());
-        assert!(!super::is_cgroup(Path::new("/tmp")).unwrap());
-    }
-
-    /// Spawns a child process of sleep(1)
-    fn spawn_proc() -> io::Result<process::Child> {
-        process::Command::new("sleep 120")
-            .stdout(process::Stdio::null())
-            .spawn()
-    }
-
-    /// Returns the path of the current cgorup inside the mount
-    fn get_path() -> PathBuf {
-        super::mount_point()
-            .unwrap()
-            .join(super::current_cgroup().unwrap())
+impl From<PathBuf> for CGroup {
+    fn from(path: PathBuf) -> Self {
+        Self { path }
     }
 }

--- a/hypervisor/src/hypervisor/partition.rs
+++ b/hypervisor/src/hypervisor/partition.rs
@@ -56,15 +56,15 @@ pub(crate) struct Run {
 
 impl Run {
     pub fn new(base: &Base, condition: StartCondition, warm_start: bool) -> TypedResult<Run> {
-        let cgroup_main = base.cgroup.new("main").typ(SystemError::CGroup)?;
-        let cgroup_periodic = base
-            .cgroup
-            .new(PartitionConstants::PERIODIC_PROCESS_CGROUP)
-            .typ(SystemError::CGroup)?;
-        let cgroup_aperiodic = base
-            .cgroup
-            .new(PartitionConstants::APERIODIC_PROCESS_CGROUP)
-            .typ(SystemError::CGroup)?;
+        let cgroup_main = CGroup::new(&base.cgroup.path(), "main")?;
+        let cgroup_periodic = CGroup::new(
+            &base.cgroup.path(),
+            PartitionConstants::PERIODIC_PROCESS_CGROUP,
+        )?;
+        let cgroup_aperiodic = CGroup::new(
+            &base.cgroup.path(),
+            PartitionConstants::APERIODIC_PROCESS_CGROUP,
+        )?;
 
         let real_uid = nix::unistd::getuid();
         let real_gid = nix::unistd::getgid();
@@ -91,11 +91,7 @@ impl Run {
                 .flag_newns()
                 .flag_newipc()
                 .flag_newnet()
-                .flag_into_cgroup(
-                    &std::fs::File::open(base.cgroup.get_path())
-                        .typ(SystemError::CGroup)?
-                        .as_raw_fd(),
-                )
+                .flag_into_cgroup(&base.cgroup.get_fd()?.as_raw_fd())
                 .call()
         }
         .typ(SystemError::Panic)?
@@ -275,7 +271,7 @@ impl Run {
 
     pub fn unfreeze_aperiodic(&self) -> TypedResult<bool> {
         if self.aperiodic {
-            self.cgroup_aperiodic.unfreeze().typ(SystemError::CGroup)?;
+            self.cgroup_aperiodic.unfreeze()?;
             return Ok(true);
         }
         Ok(false)
@@ -283,7 +279,7 @@ impl Run {
 
     pub fn freeze_aperiodic(&self) -> TypedResult<bool> {
         if self.aperiodic {
-            self.cgroup_aperiodic.freeze().typ(SystemError::CGroup)?;
+            self.cgroup_aperiodic.freeze()?;
             return Ok(true);
         }
         Ok(false)
@@ -291,26 +287,23 @@ impl Run {
 
     pub fn unfreeze_periodic(&self) -> TypedResult<bool> {
         if self.periodic {
-            self.cgroup_periodic.unfreeze().typ(SystemError::CGroup)?;
+            self.cgroup_periodic.unfreeze()?;
             return Ok(true);
         }
         Ok(false)
     }
 
     pub fn periodic_events(&self) -> TypedResult<OwnedFd> {
-        OwnedFd::try_from(
-            std::fs::File::open(self.cgroup_periodic.get_events_path()).typ(SystemError::CGroup)?,
-        )
-        .typ(SystemError::CGroup)
+        self.cgroup_periodic.events_file()
     }
 
     pub fn is_periodic_frozen(&self) -> TypedResult<bool> {
-        self.cgroup_periodic.frozen().typ(SystemError::CGroup)
+        self.cgroup_periodic.is_frozen()
     }
 
     pub fn freeze_periodic(&self) -> TypedResult<bool> {
         if self.periodic {
-            self.cgroup_periodic.freeze().typ(SystemError::CGroup)?;
+            self.cgroup_periodic.freeze()?;
             return Ok(true);
         }
         Ok(false)
@@ -356,17 +349,17 @@ impl Run {
 
         base.freeze()?;
 
-        if !self.cgroup_aperiodic.populated().typ(SystemError::CGroup)? {
+        if !self.cgroup_aperiodic.member()?.is_empty() {
             self.aperiodic = true;
         }
 
-        if !self.cgroup_periodic.populated().typ(SystemError::CGroup)? {
+        if !self.cgroup_periodic.member()?.is_empty() {
             self.periodic = true;
         }
 
         // Move main process to own cgroup
-        self.cgroup_main.freeze().typ(SystemError::CGroup)?;
-        self.cgroup_main.mv(self.main).typ(SystemError::CGroup)?;
+        self.cgroup_main.freeze()?;
+        self.cgroup_main.add_process(self.main)?;
 
         self.freeze_aperiodic()?;
         self.freeze_periodic()?;
@@ -374,7 +367,7 @@ impl Run {
         self.mode = OperatingMode::Normal;
         self.mode_file.write(&self.mode)?;
 
-        self.cgroup_aperiodic.unfreeze().typ(SystemError::CGroup)?;
+        self.cgroup_aperiodic.unfreeze()?;
         base.unfreeze()?;
         Ok(())
     }
@@ -391,7 +384,11 @@ impl Run {
         }
 
         base.freeze()?;
-        base.kill()?;
+        // maybe do not wait for that long. Should only happen within a partition ime window
+        if !base.kill_all_timeout(Duration::from_millis(10))? {
+            return Err(anyhow!("Kill all in Start Transition took more than 10ms"))
+                .typ(SystemError::Panic);
+        }
 
         *self = Run::new(base, cond, warm_start).typ(SystemError::PartitionInit)?;
 
@@ -434,7 +431,7 @@ impl Base {
     }
 
     pub fn unfreeze(&self) -> TypedResult<()> {
-        self.cgroup.unfreeze().typ(SystemError::CGroup)
+        self.cgroup.unfreeze()
     }
 
     pub fn sampling_fds(&self) -> Vec<RawFd> {
@@ -445,19 +442,19 @@ impl Base {
     }
 
     pub fn freeze(&self) -> TypedResult<()> {
-        self.cgroup.freeze().typ(SystemError::CGroup)
+        self.cgroup.freeze()
     }
 
     pub fn is_frozen(&self) -> TypedResult<bool> {
-        self.cgroup.frozen().typ(SystemError::CGroup)
+        self.cgroup.is_frozen()
     }
 
     pub fn part_hm(&self) -> &PartitionHMTable {
         &self.hm
     }
 
-    pub fn kill(&self) -> TypedResult<()> {
-        self.cgroup.kill().typ(SystemError::CGroup)
+    pub fn kill_all_timeout(&self, timeout: Duration) -> TypedResult<bool> {
+        self.cgroup.kill_all_timeout(timeout)
     }
 }
 
@@ -474,7 +471,7 @@ impl Partition {
         sampling: &HashMap<String, Sampling>,
     ) -> TypedResult<Self> {
         // Todo implement drop for cgroup (in error case)
-        let cgroup = CGroup::new_root(cgroup_root, &config.name).typ(SystemError::PartitionInit)?;
+        let cgroup = CGroup::new(cgroup_root, &config.name).typ(SystemError::PartitionInit)?;
 
         let sampling_channel = sampling
             .iter()
@@ -577,10 +574,10 @@ impl Partition {
     }
 
     pub(crate) fn freeze(&self) -> TypedResult<()> {
-        self.base.cgroup.freeze().typ(SystemError::CGroup)
+        self.base.cgroup.freeze()
     }
 
-    pub(crate) fn rm(self) -> TypedResult<()> {
-        self.base.cgroup.rm().typ(SystemError::CGroup)
+    pub(crate) fn delete(self, timeout: Duration) -> TypedResult<()> {
+        self.base.cgroup.delete(timeout)
     }
 }

--- a/hypervisor/src/main.rs
+++ b/hypervisor/src/main.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use anyhow::anyhow;
 use clap::Parser;
-use linux_apex_core::cgroup;
+use linux_apex_core::cgroup::CGroup;
 use linux_apex_core::error::{ErrorLevel, LeveledResult, ResultExt, SystemError, TypedResultExt};
 use linux_apex_core::health::ModuleRecoveryAction;
 use linux_apex_hypervisor::hypervisor::config::Config;
@@ -65,9 +65,7 @@ fn main() -> LeveledResult<()> {
     trace!("My pid is {}", my_pid.pid);
 
     // assumes cgroupv2
-    let cgroups_mount_point = cgroup::mount_point()
-        .typ(SystemError::CGroup)
-        .lev(ErrorLevel::ModuleInit)?;
+    let cgroups_mount_point = CGroup::mount_point().lev(ErrorLevel::ModuleInit)?;
 
     let cgroup = args.cgroup.get_or_insert_with(|| {
         let cgroups = my_pid

--- a/partition/src/process.rs
+++ b/partition/src/process.rs
@@ -6,7 +6,6 @@ use std::sync::Mutex;
 use anyhow::anyhow;
 use apex_rs::bindings::*;
 use apex_rs::prelude::{ProcessAttribute, SystemTime};
-use linux_apex_core::cgroup;
 use linux_apex_core::cgroup::CGroup;
 use linux_apex_core::error::{
     ErrorLevel, LeveledResult, ResultExt, SystemError, TypedResult, TypedResultExt,
@@ -174,9 +173,7 @@ impl Process {
         let name = self.name()?;
 
         let cg = self.cg().lev(ErrorLevel::Partition)?;
-        cg.freeze()
-            .typ(SystemError::CGroup)
-            .lev(ErrorLevel::Partition)?;
+        cg.freeze().lev(ErrorLevel::Partition)?;
 
         let stack = unsafe {
             STACKS[self.periodic as usize]
@@ -194,7 +191,7 @@ impl Process {
             //setrlimit(Resource::RLIMIT_STACK, stack_size - 2000, stack_size - 2000).unwrap();
 
             let cg = self.cg().unwrap();
-            cg.mv(getpid()).unwrap();
+            cg.add_process(getpid()).unwrap();
             (self.attr.entry_point)();
             0
         });
@@ -202,7 +199,7 @@ impl Process {
         // Make extra sure that the process is in the cgroup
         let child = nix::sched::clone(cbk, stack, CloneFlags::empty(), Some(SIGCHLD as i32))
             .lev_typ(SystemError::Panic, ErrorLevel::Partition)?;
-        cg.mv(child).unwrap();
+        cg.add_process(child).unwrap();
 
         self.pid.write(&child).lev(ErrorLevel::Partition)?;
 
@@ -218,8 +215,7 @@ impl Process {
         } else {
             PartitionConstants::APERIODIC_PROCESS_CGROUP
         };
-        CGroup::new_root(cgroup::mount_point().typ(SystemError::CGroup)?, cg_name)
-            .typ(SystemError::CGroup)
+        CGroup::new(CGroup::mount_point()?, cg_name)
     }
 
     pub fn periodic(&self) -> bool {


### PR DESCRIPTION
This commit reverts the cgroup rewrite performed in #12, because it apparently was not tested a lot. Most pull requests and bug reports in the past few months were related to the new cgroup module. It even led to the lack of execution for the periodic process.

While the legacy implementation is not perfect either, it is still better than the current one, because it's author had a wider overview on what was going on.