### PR TITLE
Import process cgroup root inside partition

### DIFF
--- a/core/src/cgroup.rs
+++ b/core/src/cgroup.rs
@@ -41,10 +41,8 @@ impl CGroup {
 
         let path = PathBuf::from(path.as_ref()).join(name);
 
-        // TODO this is a hotfix for #17. We should revisit this issue, trying to find
-        // our why the same CGroup is created multiple times.
         if path.exists() {
-            warn!("CGroup {path:?} already exists");
+            bail!("CGroup {path:?} already exists");
         } else {
             // will fail if the path already exists
             fs::create_dir(&path)?;

--- a/partition/src/process.rs
+++ b/partition/src/process.rs
@@ -218,8 +218,11 @@ impl Process {
         } else {
             PartitionConstants::APERIODIC_PROCESS_CGROUP
         };
-        CGroup::new_root(cgroup::mount_point().typ(SystemError::CGroup)?, cg_name)
-            .typ(SystemError::CGroup)
+
+        let path = cgroup::mount_point().typ(SystemError::CGroup)?;
+        let path = path.join(cg_name);
+
+        CGroup::import_root(path).typ(SystemError::CGroup)
     }
 
     pub fn periodic(&self) -> bool {


### PR DESCRIPTION
This imports the existing root cgroup of the partition processes instead of
recreating them. The cgroup root of a partition process is always created when
a partition is created. Attempting to create it again inside the partition is
therefore redundant and triggers a warning. As per the documentation, recreating
an existing cgroup root should always fail, because it indicates a logic error.
Therefore, this commit also changes `new_root` to treat recreating an existing
root as an error.
