### PR TITLE
 hypervisor: support user space mounts 

### DIFF
--- a/hypervisor/src/hypervisor/config.rs
+++ b/hypervisor/src/hypervisor/config.rs
@@ -38,6 +38,8 @@ pub struct Partition {
     pub devices: Vec<Device>,
     #[serde(default)]
     pub hm_table: PartitionHMTable,
+    #[serde(default)]
+    pub mounts: Vec<(PathBuf, PathBuf)>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]


### PR DESCRIPTION
This depends on #43 

This commit introduces the ability to mount custom files and folders
from the host operating system onto a partition.

The hypervisor configuration is adjusted as follows at partition layer:
```yaml
mounts:
  - [ "/dev/urandom", "/dev/urandom"]
  - [ "/dev/urandom", "/dev/random"]
  - [ "/a/file/on/the/host", "/guest" ]
```

Future features could additionally include the ability to mount things
read-only, etc.

Fixes https://github.com/aeronautical-informatics/apex-linux/issues/42

cc @wucke13 