### PR TITLE
Make UDP socket available to partitions

### DIFF
--- a/core/src/ipc.rs
+++ b/core/src/ipc.rs
@@ -1,12 +1,17 @@
 //! Implementation of IPC
-use std::io::ErrorKind;
+use std::io::{ErrorKind, IoSlice, IoSliceMut};
 use std::marker::PhantomData;
 use std::os::unix::net::UnixDatagram;
 use std::os::unix::prelude::{AsRawFd, FromRawFd, RawFd};
 use std::time::Duration;
 
 use anyhow::Error;
-use nix::sys::socket::{socketpair, AddressFamily, SockFlag, SockType};
+use nix::cmsg_space;
+use nix::errno::Errno;
+use nix::sys::socket::{
+    recvmsg, sendmsg, socketpair, AddressFamily, ControlMessage, ControlMessageOwned, MsgFlags,
+    SockFlag, SockType,
+};
 use polling::{Event, Poller};
 use serde::{Deserialize, Serialize};
 
@@ -129,6 +134,110 @@ impl<T> FromRawFd for IpcReceiver<T> {
         Self {
             socket: UnixDatagram::from_raw_fd(fd),
             _p: PhantomData,
+        }
+    }
+}
+
+/// Creates a pair of sockets that are meant for passing file descriptors to partitions.
+pub fn io_pair<T>() -> TypedResult<(IoSender<T>, IoReceiver<T>)>
+where
+    T: AsRawFd,
+{
+    let (tx, rx) = socketpair(
+        AddressFamily::Unix,
+        SockType::Datagram,
+        None,
+        SockFlag::empty(),
+    )
+    .typ(SystemError::Panic)?;
+    unsafe { Ok((IoSender::from_raw_fd(tx), IoReceiver::from_raw_fd(rx))) }
+}
+
+#[derive(Debug)]
+/// Internal data type for the IO resource sender
+pub struct IoSender<T> {
+    socket: UnixDatagram,
+    _p: PhantomData<T>,
+}
+
+impl<T> IoSender<T>
+where
+    T: AsRawFd,
+{
+    /// Sends a resource to the receiving socket.
+    pub fn try_send(&self, resource: T) -> TypedResult<()> {
+        let fds = [resource.as_raw_fd()];
+        let cmsg = [ControlMessage::ScmRights(&fds)];
+        // Have to send some bytes along with the ancillary data.
+        let iov = [IoSlice::new(&[0u8])];
+        let io_fd = self.socket.as_raw_fd();
+        sendmsg::<()>(io_fd, &iov, &cmsg, MsgFlags::empty(), None).typ(SystemError::Panic)?;
+        Ok(())
+    }
+}
+
+impl<T> IoReceiver<T>
+where
+    T: FromRawFd,
+{
+    /// Returns the next available IO resource.
+    /// Returns `None`, if no further resources can be read from the socket.
+    pub fn try_receive(&self) -> TypedResult<Option<T>> {
+        let mut cmsg = cmsg_space!(RawFd);
+        let mut iobuf = [0u8];
+        let mut iov = [IoSliceMut::new(&mut iobuf)];
+        let io_fd = self.socket.as_raw_fd();
+        match recvmsg::<()>(io_fd, &mut iov, Some(&mut cmsg), MsgFlags::MSG_DONTWAIT) {
+            Ok(msg) => {
+                if let Some(ControlMessageOwned::ScmRights(fds)) = msg.cmsgs().next() {
+                    if let &[raw_fd] = fds.as_slice() {
+                        return Ok(Some(unsafe { T::from_raw_fd(raw_fd) }));
+                    }
+                }
+                Ok(None)
+            }
+            // This should never block since the socket is only written to before the partition starts.
+            Err(e) if e != Errno::EAGAIN && e != Errno::EINTR => {
+                Err(Error::from(e)).typ(SystemError::Panic)
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Internal data type for the IO resource sender
+pub struct IoReceiver<T> {
+    socket: UnixDatagram,
+    _p: PhantomData<T>,
+}
+
+impl<T> AsRawFd for IoSender<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.socket.as_raw_fd()
+    }
+}
+
+impl<T> AsRawFd for IoReceiver<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.socket.as_raw_fd()
+    }
+}
+
+impl<T> FromRawFd for IoSender<T> {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self {
+            socket: unsafe { UnixDatagram::from_raw_fd(fd) },
+            _p: PhantomData::default(),
+        }
+    }
+}
+
+impl<T> FromRawFd for IoReceiver<T> {
+    unsafe fn from_raw_fd(fd: RawFd) -> Self {
+        Self {
+            socket: unsafe { UnixDatagram::from_raw_fd(fd) },
+            _p: PhantomData::default(),
         }
     }
 }

--- a/core/src/partition.rs
+++ b/core/src/partition.rs
@@ -20,6 +20,10 @@ pub struct PartitionConstants {
     pub sender_fd: RawFd,
     pub start_time_fd: RawFd,
     pub partition_mode_fd: RawFd,
+
+    // A UNIX domain socket, that is used to send file descriptons to the partition.
+    pub io_fd: RawFd,
+
     pub sampling: Vec<SamplingConstant>,
 }
 

--- a/hypervisor/src/hypervisor/config.rs
+++ b/hypervisor/src/hypervisor/config.rs
@@ -38,7 +38,12 @@ pub struct Partition {
     pub devices: Vec<Device>,
     #[serde(default)]
     pub hm_table: PartitionHMTable,
+    #[serde(default)]
+    pub udp_ports: Vec<UdpAddress>,
 }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct UdpAddress(pub String);
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Device {

--- a/hypervisor/src/hypervisor/partition.rs
+++ b/hypervisor/src/hypervisor/partition.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
+use std::net::UdpSocket;
 use std::os::unix::prelude::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
@@ -17,7 +18,7 @@ use linux_apex_core::error::{
 use linux_apex_core::file::TempFile;
 use linux_apex_core::health::PartitionHMTable;
 use linux_apex_core::health_event::PartitionCall;
-use linux_apex_core::ipc::{channel_pair, IpcReceiver};
+use linux_apex_core::ipc::{channel_pair, io_pair, IoSender, IpcReceiver};
 use linux_apex_core::partition::{PartitionConstants, SamplingConstant};
 use linux_apex_core::sampling::Sampling;
 use nix::mount::{mount, umount2, MntFlags, MsFlags};
@@ -25,6 +26,7 @@ use nix::unistd::{chdir, close, pivot_root, setgid, setuid, Gid, Pid, Uid};
 use procfs::process::Process;
 use tempfile::{tempdir, TempDir};
 
+use super::config::UdpAddress;
 use super::scheduler::{PartitionTimeWindow, Timeout};
 use crate::hypervisor::config::Partition as PartitionConfig;
 use crate::hypervisor::linux::SYSTEM_START_TIME;
@@ -64,6 +66,7 @@ pub(crate) struct Run {
     _mode_file_fd: OwnedFd,
     mode_file: TempFile<OperatingMode>,
     call_rx: IpcReceiver<PartitionCall>,
+    _io_tx: IoSender<UdpSocket>,
 }
 
 impl FileMounter {
@@ -129,6 +132,13 @@ impl Run {
         let mode_file_fd = unsafe { OwnedFd::from_raw_fd(mode_file.as_raw_fd()) };
         mode_file.write(&mode)?;
 
+        // Create the UDP sockets that were specified in the configuration of the partition.
+        let (io_tx, io_rx) = io_pair::<UdpSocket>()?;
+        for UdpAddress(addr) in base.udp_ports.iter() {
+            let udp_socket = UdpSocket::bind(addr).typ(SystemError::Panic)?;
+            io_tx.try_send(udp_socket).typ(SystemError::Panic)?;
+        }
+
         let pid = match unsafe {
             Clone3::default()
                 .flag_newcgroup()
@@ -171,6 +181,7 @@ impl Run {
                 keep.push(sys_time.as_raw_fd());
                 keep.push(call_tx.as_raw_fd());
                 keep.push(mode_file.as_raw_fd());
+                keep.push(io_rx.as_raw_fd());
 
                 Partition::release_fds(&keep).unwrap();
 
@@ -244,6 +255,7 @@ impl Run {
                     sender_fd: call_tx.as_raw_fd(),
                     start_time_fd: sys_time.as_raw_fd(),
                     partition_mode_fd: mode_file.as_raw_fd(),
+                    io_fd: io_rx.as_raw_fd(),
                     sampling: base
                         .sampling_channel
                         .clone()
@@ -288,6 +300,7 @@ impl Run {
             mode,
             mode_file,
             call_rx,
+            _io_tx: io_tx,
             periodic: false,
             aperiodic: false,
             _mode_file_fd: mode_file_fd,
@@ -455,6 +468,7 @@ pub(crate) struct Base {
     duration: Duration,
     period: Duration,
     working_dir: TempDir,
+    udp_ports: Vec<UdpAddress>,
 }
 
 impl Base {
@@ -523,6 +537,7 @@ impl Partition {
             working_dir,
             hm: config.hm_table,
             sampling_channel,
+            udp_ports: config.udp_ports,
         };
         // TODO use StartCondition::HmModuleRestart in case of a ModuleRestart!!
         let run =

--- a/partition/src/lib.rs
+++ b/partition/src/lib.rs
@@ -1,13 +1,14 @@
 #[macro_use]
 extern crate log;
 
+use std::net::UdpSocket;
 use std::os::unix::prelude::FromRawFd;
 use std::time::{Duration, Instant};
 
 use apex_rs::prelude::OperatingMode;
 use linux_apex_core::file::{get_memfd, TempFile};
 use linux_apex_core::health_event::PartitionCall;
-use linux_apex_core::ipc::IpcSender;
+use linux_apex_core::ipc::{IoReceiver, IpcSender};
 use linux_apex_core::partition::*;
 use memmap2::{MmapMut, MmapOptions};
 use once_cell::sync::Lazy;
@@ -73,6 +74,9 @@ pub(crate) static SAMPLING_PORTS: Lazy<TempFile<ArrayVec<[SamplingPortsType; 2]>
 
 pub(crate) static SENDER: Lazy<IpcSender<PartitionCall>> =
     Lazy::new(|| unsafe { IpcSender::from_raw_fd(CONSTANTS.sender_fd) });
+
+pub(crate) static IO_RX: Lazy<IoReceiver<UdpSocket>> =
+    Lazy::new(|| unsafe { IoReceiver::<UdpSocket>::from_raw_fd(CONSTANTS.io_fd) });
 
 pub(crate) static SIGNAL_STACK: Lazy<MmapMut> = Lazy::new(|| {
     MmapOptions::new()


### PR DESCRIPTION
This is a PoC that makes a UDP socket available to every partition. The UDP socket can do networking outside of the partition's namespace.

Add config option for UDP ports